### PR TITLE
chore: promote services to v3.0.21 in saas-dev-euw1

### DIFF
--- a/.k8s/charts/core/identity-operations/values-dev-euw1-blue.yaml
+++ b/.k8s/charts/core/identity-operations/values-dev-euw1-blue.yaml
@@ -140,7 +140,7 @@ dispatcher:
     periodSeconds: 10
 consumer:
   repository: 314146327420.dkr.ecr.eu-west-1.amazonaws.com/identity-operations-processor/core/consumer
-  tag: v3.0.20
+  tag: v3.0.21
   pullPolicy: IfNotPresent
   env:
     ###>>> General ENV Variables


### PR DESCRIPTION
This PR promotes the following services to tag `v3.0.21` in `saas-dev-euw1`:

- `consumer`

Automated by GitHub Actions.